### PR TITLE
Modified the JSONValue::StringifyString method to escape wchar_t values b

### DIFF
--- a/src/JSONValue.cpp
+++ b/src/JSONValue.cpp
@@ -671,7 +671,7 @@ std::wstring JSONValue::StringifyString(const std::wstring &str)
 		{
 			str_out += L"\\t";
 		}
-		else if (chr < L' ')
+		else if (chr < L' ' || chr > L'~')
 		{
 			str_out += L"\\u";
 			for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Modified the JSONValue::StringifyString method to escape wchar_t values both below L' ' OR above L'~'. I was having problems using the library to encode JSON for objects containing wide strings with characters above L'~'.
