### PR TITLE
Mark all single argument constructors as explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,18 @@ OBJECTS=$(SOURCES:src/%.cpp=obj/%.o)
 EXECUTABLE=JSONDemo
 
 all:	$(SOURCES) $(EXECUTABLE)
-	
-$(EXECUTABLE):	$(OBJECTS) 
+
+$(EXECUTABLE):	$(OBJECTS)
 		$(CC) $(LFLAGS) $(OBJECTS) -o $@
 
 obj/%.o:	src/%.cpp $(HEADERS)
 		@test -d $(@D) || mkdir -p $(@D)
 		$(CC) $(CFLAGS) $(@:obj/%.o=src/%.cpp) -o $@
 
+test: $(EXECUTABLE)
+	./JSONDemo -t
+
 clean:
 		rm -f $(OBJECTS) $(EXECUTABLE)
 
+.PHONY: clean test

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ obj/%.o:	src/%.cpp $(HEADERS)
 		$(CC) $(CFLAGS) $(@:obj/%.o=src/%.cpp) -o $@
 
 test: $(EXECUTABLE)
-		./JSONDemo -t
+		./$(EXECUTABLE) -t
 
 clean:
 		rm -f $(OBJECTS) $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ obj/%.o:	src/%.cpp $(HEADERS)
 		$(CC) $(CFLAGS) $(@:obj/%.o=src/%.cpp) -o $@
 
 test: $(EXECUTABLE)
-	./JSONDemo -t
+		./JSONDemo -t
 
 clean:
 		rm -f $(OBJECTS) $(EXECUTABLE)

--- a/src/JSONValue.h
+++ b/src/JSONValue.h
@@ -40,13 +40,13 @@ class JSONValue
 
 	public:
 		JSONValue(/*NULL*/);
-		JSONValue(const wchar_t *m_char_value);
-		JSONValue(const std::wstring &m_string_value);
-		JSONValue(bool m_bool_value);
-		JSONValue(double m_number_value);
-		JSONValue(int m_integer_value);
-		JSONValue(const JSONArray &m_array_value);
-		JSONValue(const JSONObject &m_object_value);
+		explicit JSONValue(const wchar_t *m_char_value);
+		explicit JSONValue(const std::wstring &m_string_value);
+		explicit JSONValue(bool m_bool_value);
+		explicit JSONValue(double m_number_value);
+		explicit JSONValue(int m_integer_value);
+		explicit JSONValue(const JSONArray &m_array_value);
+		explicit JSONValue(const JSONObject &m_object_value);
 		JSONValue(const JSONValue &m_source);
 		~JSONValue();
 


### PR DESCRIPTION
In several cases during the use of this library, I had weird output that I had to debug.

The root cause was almost always a JSONValue being created with a pointer argument instead of the dereferenced value. (The pointer was always being coerced into a boolean without a compile error). 

This PR fixes this issue by making all the single argument constructors explicit.
In addition, the Makefile has been updated to support a test target.